### PR TITLE
Py310 fix

### DIFF
--- a/temporal/activity_loop.py
+++ b/temporal/activity_loop.py
@@ -9,7 +9,7 @@ from grpclib import GRPCError
 from temporal.activity import ActivityContext, ActivityTask, complete_exceptionally, complete
 from temporal.api.taskqueue.v1 import TaskQueue, TaskQueueMetadata
 from temporal.converter import get_fn_args_type_hints
-from temporal.retry import RetryException, retry
+from temporal.retry import retry
 from temporal.service_helpers import get_identity
 from temporal.worker import Worker, StopRequestedException
 from temporal.api.workflowservice.v1 import WorkflowServiceStub as WorkflowService, PollActivityTaskQueueRequest, \
@@ -93,4 +93,3 @@ async def activity_task_loop_func(worker: Worker):
     finally:
         worker.notify_thread_stopped()
         logger.info("Activity loop ended")
-        raise RetryException('sleep')

--- a/temporal/retry.py
+++ b/temporal/retry.py
@@ -1,5 +1,6 @@
 import asyncio
 import calendar
+from socket import gaierror
 import time
 
 INITIAL_DELAY_SECONDS = 3
@@ -17,8 +18,8 @@ def retry(logger=None):
                     await fp(*args, **kwargs)
                     logger.debug("@retry decorated function %s exited, ending retry loop", fp.__name__)
                     break
-                except asyncio.CancelledError:
-                    logger.info("%s raised CancelledError, retrying...", fp.__name__)
+                except (asyncio.CancelledError, gaierror) as err:
+                    logger.info(f"{fp.__name__} raised {err}, retrying...")
                     await asyncio.sleep(INITIAL_DELAY_SECONDS)
                 except Exception as ex:
                     now = calendar.timegm(time.gmtime())

--- a/temporal/retry.py
+++ b/temporal/retry.py
@@ -17,7 +17,7 @@ def retry(logger=None):
                     await fp(*args, **kwargs)
                     logger.debug("@retry decorated function %s exited, ending retry loop", fp.__name__)
                     break
-                except asyncio.CancelledError as ex:
+                except asyncio.CancelledError:
                     logger.info("%s raised CancelledError, retrying...", fp.__name__)
                     await asyncio.sleep(INITIAL_DELAY_SECONDS)
                 except Exception as ex:

--- a/temporal/retry.py
+++ b/temporal/retry.py
@@ -17,7 +17,10 @@ def retry(logger=None):
                     await fp(*args, **kwargs)
                     logger.debug("@retry decorated function %s exited, ending retry loop", fp.__name__)
                     break
-                except (Exception, asyncio.CancelledError) as ex:
+                except asyncio.CancelledError as ex:
+                    logger.info("%s raised CancelledError, retrying...", fp.__name__)
+                    await asyncio.sleep(INITIAL_DELAY_SECONDS)
+                except Exception as ex:
                     now = calendar.timegm(time.gmtime())
                     if last_failed_time == -1 or (now - last_failed_time) > RESET_DELAY_AFTER_SECONDS:
                         delay_seconds = INITIAL_DELAY_SECONDS

--- a/temporal/retry.py
+++ b/temporal/retry.py
@@ -17,7 +17,7 @@ def retry(logger=None):
                     await fp(*args, **kwargs)
                     logger.debug("@retry decorated function %s exited, ending retry loop", fp.__name__)
                     break
-                except Exception as ex:
+                except (Exception, asyncio.CancelledError) as ex:
                     now = calendar.timegm(time.gmtime())
                     if last_failed_time == -1 or (now - last_failed_time) > RESET_DELAY_AFTER_SECONDS:
                         delay_seconds = INITIAL_DELAY_SECONDS

--- a/temporal/retry.py
+++ b/temporal/retry.py
@@ -7,8 +7,6 @@ BACK_OFF_MULTIPLIER = 2
 MAX_DELAY_SECONDS = 5 * 60
 RESET_DELAY_AFTER_SECONDS = 10 * 60
 
-class RetryException(Exception):
-    pass
 
 def retry(logger=None):
     def wrapper(fp):
@@ -19,9 +17,6 @@ def retry(logger=None):
                     await fp(*args, **kwargs)
                     logger.debug("@retry decorated function %s exited, ending retry loop", fp.__name__)
                     break
-                except RetryException:
-                    logger.info('sleeping...')
-                    await asyncio.sleep(INITIAL_DELAY_SECONDS)
                 except Exception as ex:
                     now = calendar.timegm(time.gmtime())
                     if last_failed_time == -1 or (now - last_failed_time) > RESET_DELAY_AFTER_SECONDS:


### PR DESCRIPTION
When running workers, Activity task worker and Decision task worker throw an `asyncio.CancelledError` error the first time they are started(not sure why), in python 3.7, the retry decorator excepts that error using `except Exception` and trys to restart the worker which solves the issue.
In python 3.8, `asyncio.CancelledError` [became](https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.CancelledError) a subclass of BaseException instead of Exception, so the error is no longer excepted and is raised instead, causing the workers to not start.
The previous commit solved this issue for the Activity task worker, but not for the Decision task worker(which failed for our case), this PR solves both issues by adding handling of the `asyncio.CancelledError` error to the retry decorator ~~so that it would behave exactly as it did in python 3.7.~~
Handling of `asyncio.CancelledError` is separated from handling of `Exception` to not call `logger.error()`.